### PR TITLE
feat(server): add world type selection and linux fixes

### DIFF
--- a/UIMod/config.html
+++ b/UIMod/config.html
@@ -101,16 +101,16 @@
                     <label for="WorldType">World Type:</label>
                     <select id="WorldType" name="WorldType">
                         <option value="">(None)</option>
-                        <option value="moon">Moon</option>
-                        <option value="mars">Mars</option>
-                        <option value="europa">Europa</option>
-                        <option value="europa2">Europa 2</option>
-                        <option value="mimas">Mimas</option>
-                        <option value="vulcan">Vulcan</option>
-                        <option value="vulcan2">Vulcan 2</option>
-                        <option value="space">Space</option>
-                        <option value="loulan">Loulan</option>
-                        <option value="venus">Venus</option>
+                        <option value="Moon">Moon</option>
+                        <option value="Mars">Mars</option>
+                        <option value="Europa">Europa</option>
+                        <option value="Europa2">Europa 2</option>
+                        <option value="Mimas">Mimas</option>
+                        <option value="Vulcan">Vulcan</option>
+                        <option value="Vulcan2">Vulcan 2</option>
+                        <option value="Space">Space</option>
+                        <option value="Loulan">Loulan</option>
+                        <option value="Venus">Venus</option>
                     </select>
                 </div>
 

--- a/UIMod/config.html
+++ b/UIMod/config.html
@@ -98,6 +98,23 @@
                 </div>
 
                 <div class="form-group">
+                    <label for="WorldType">World Type:</label>
+                    <select id="WorldType" name="WorldType">
+                        <option value="">(None)</option>
+                        <option value="moon">Moon</option>
+                        <option value="mars">Mars</option>
+                        <option value="europa">Europa</option>
+                        <option value="europa2">Europa 2</option>
+                        <option value="mimas">Mimas</option>
+                        <option value="vulcan">Vulcan</option>
+                        <option value="vulcan2">Vulcan 2</option>
+                        <option value="space">Space</option>
+                        <option value="loulan">Loulan</option>
+                        <option value="venus">Venus</option>
+                    </select>
+                </div>
+
+                <div class="form-group">
                     <label for="AdditionalParams">Additional Parameters:</label>
                     <input type="text" id="AdditionalParams" name="AdditionalParams" value="{{AdditionalParams}}">
                     <div class="input-info">Format: CustomParam1 Value1 CustomParam2 Value2</div>

--- a/src/api/api.go
+++ b/src/api/api.go
@@ -21,6 +21,7 @@ type Config struct {
 	} `xml:"server"`
 
 	SaveFileName string `xml:"saveFileName"`
+	WorldType    string `xml:"worldType"`
 }
 
 func StartAPI() {

--- a/src/api/apiconfig.go
+++ b/src/api/apiconfig.go
@@ -71,6 +71,7 @@ func HandleConfig(w http.ResponseWriter, r *http.Request) {
 		"{{ServerName}}":       settingsMap["ServerName"],
 		"{{AdditionalParams}}": getAdditionalParams(settings),
 		"{{SaveFileName}}":     config.SaveFileName,
+		"{{WorldType}}":        config.WorldType,
 	}
 
 	for placeholder, value := range replacements {
@@ -94,6 +95,7 @@ func getAdditionalParams(settings []string) string {
 		"AdminPassword":    true,
 		"ServerMaxPlayers": true,
 		"ServerName":       true,
+		"WorldType":        true,
 	}
 
 	var additionalParams []string
@@ -145,6 +147,9 @@ func SaveConfig(w http.ResponseWriter, r *http.Request) {
 		if serverName := r.FormValue("ServerName"); serverName != "" {
 			settings = append(settings, "ServerName", serverName)
 		}
+		if worldType := r.FormValue("WorldType"); worldType != "" {
+			settings = append(settings, "WorldType", worldType)
+		}
 
 		// Append additional parameters if any
 		additionalParams := r.FormValue("AdditionalParams")
@@ -171,6 +176,7 @@ func SaveConfig(w http.ResponseWriter, r *http.Request) {
 				Settings: settingsStr,
 			},
 			SaveFileName: r.FormValue("saveFileName"),
+			WorldType:    r.FormValue("WorldType"),
 		}
 
 		configPath := "./UIMod/config.xml"

--- a/src/api/processmanagement.go
+++ b/src/api/processmanagement.go
@@ -50,7 +50,7 @@ func StartServer(w http.ResponseWriter, r *http.Request) {
 	var localIpAddressArg string
 	var otherArgs []string
 	for _, setting := range settings {
-		if strings.HasPrefix(setting, "LocalIpAddress=") {
+		if strings.HasPrefix(setting, "LocalIpAddress") {
 			localIpAddressArg = setting
 		} else {
 			otherArgs = append(otherArgs, setting)

--- a/src/api/processmanagement.go
+++ b/src/api/processmanagement.go
@@ -39,11 +39,17 @@ func StartServer(w http.ResponseWriter, r *http.Request) {
 	alwaysNeededParams := []string{"-batchmode", "-nographics"}
 	args := alwaysNeededParams
 	if runtime.GOOS == "windows" {
-		args = append(alwaysNeededParams, "-LOAD", config.SaveFileName, config.WorldType, "-settings")
+		args = append(args, "-LOAD", config.SaveFileName)
+	} else { // Linux
+		args = append(args, "-LOAD", config.SaveFileName, "-logFile", "./debug.log")
 	}
-	if runtime.GOOS == "linux" {
-		args = append(alwaysNeededParams, "-LOAD", "-logFile \"./debug.log\"", config.SaveFileName, config.WorldType, "-settings")
+
+	//Handle WorldType - only append if not empty
+	if config.WorldType != "" {
+		args = append(args, config.WorldType)
 	}
+
+	args = append(args, "-settings") // "-settings" before other settings
 
 	// Process settings to ensure LocalIpAddress is last
 	settings := strings.Split(config.Server.Settings, " ")

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -54,20 +54,20 @@ var (
 
 func (c *Config) ValidateWorldType() error {
 	allowedWorldTypes := map[string]bool{
-		"moon":    true,
-		"mars":    true,
-		"europa":  true,
-		"europa2": true,
-		"mimas":   true,
-		"vulcan":  true,
-		"vulcan2": true,
-		"space":   true,
-		"loulan":  true,
-		"venus":   true,
+		"Moon":    true,
+		"Mars":    true,
+		"Europa":  true,
+		"Europa2": true,
+		"Mimas":   true,
+		"Vulcan":  true,
+		"Vulcan2": true,
+		"Space":   true,
+		"Loulan":  true,
+		"Venus":   true,
 		"":        true, //Allow empty string for no world type
 	}
 	if !allowedWorldTypes[c.WorldType] {
-		return fmt.Errorf("invalid WorldType: %s. Allowed values are: moon, mars, europa, europa2, mimas, vulcan, vulcan2, space, loulan, venus", c.WorldType)
+		return fmt.Errorf("invalid WorldType: %s. Allowed values are: Moon, Mars, Europa, Europa2, Mimas, Vulcan, Vulcan2, Space, Loulan, Venus", c.WorldType)
 	}
 	return nil
 }

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -3,6 +3,7 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"time"
 
@@ -21,6 +22,7 @@ type Config struct {
 	IsDiscordEnabled        bool   `json:"isDiscordEnabled"`
 	ErrorChannelID          string `json:"errorChannelID"`
 	GameBranch              string `json:"gameBranch"`
+	WorldType               string `json:"worldType"`
 }
 
 var (
@@ -45,10 +47,30 @@ var (
 	IsDiscordEnabled          bool
 	IsFirstTimeSetup          bool
 	GameBranch                string
-	Version = "3.0.1"
+	Version                   = "3.0.1"
 	Branch                    = "release"
 	GameServerAppID           = "600760" // Steam App ID for Stationeers Dedicated Server
 )
+
+func (c *Config) ValidateWorldType() error {
+	allowedWorldTypes := map[string]bool{
+		"moon":    true,
+		"mars":    true,
+		"europa":  true,
+		"europa2": true,
+		"mimas":   true,
+		"vulcan":  true,
+		"vulcan2": true,
+		"space":   true,
+		"loulan":  true,
+		"venus":   true,
+		"":        true, //Allow empty string for no world type
+	}
+	if !allowedWorldTypes[c.WorldType] {
+		return fmt.Errorf("invalid WorldType: %s. Allowed values are: moon, mars, europa, europa2, mimas, vulcan, vulcan2, space, loulan, venus", c.WorldType)
+	}
+	return nil
+}
 
 func LoadConfig(filename string) (*Config, error) {
 	file, err := os.Open(filename)
@@ -61,6 +83,9 @@ func LoadConfig(filename string) (*Config, error) {
 	decoder := json.NewDecoder(file)
 	err = decoder.Decode(&config)
 	if err != nil {
+		return nil, err
+	}
+	if err := config.ValidateWorldType(); err != nil {
 		return nil, err
 	}
 	//print all the values to console


### PR DESCRIPTION
- Added world type config option
- Updated server start command to now put LocalIp Address as the last parameter and add file logging to linux servers
- Improved config file handling
- Added world type validation
- Implemented OS-specific args- Added world type config option
